### PR TITLE
[COLLIDE]: Delete G2Quat_ToMatrix

### DIFF
--- a/KAIN2/Game/COLLIDE.C
+++ b/KAIN2/Game/COLLIDE.C
@@ -22,11 +22,6 @@ long collide_t1;
 struct _SVector* collide_normal0;
 struct _SVector* collide_normal1;
 
-void G2Quat_ToMatrix(struct _G2EulerAngles_Type* a1, struct _G2Matrix_Type* a2)
-{
-	UNIMPLEMENTED();
-}
-
 int COLLIDE_PointInTriangle(struct _SVector* v0, struct _SVector* v1, struct _SVector* v2, struct _SVector* point, struct _SVector* normal)//Matching - 86.63%
 {
 	int ny; // $v1

--- a/KAIN2/Game/COLLIDE.H
+++ b/KAIN2/Game/COLLIDE.H
@@ -142,8 +142,6 @@ struct COLLIDE_258fake // hashcode: 0x1D802093 (dec: 494936211)
 extern "C" {
 #endif
 
-extern void G2Quat_ToMatrix(struct _G2EulerAngles_Type* a1, struct _G2Matrix_Type* a2);
-
 extern int COLLIDE_PointInTriangle(struct _SVector *v0, struct _SVector *v1, struct _SVector *v2, struct _SVector *point, struct _SVector *normal); // 0x8001E460
 extern int COLLIDE_PointInTriangle2DPub(short *v0, short *v1, short *v2, short *point); // 0x8001E704
 extern long COLLIDE_GetNormal(short nNum, short *nrmlArray, struct _SVector *nrml); // 0x8001E750


### PR DESCRIPTION
Function doesn't appear in either ASM dump or symdump.