### PR TITLE
[TIMER]: Update gameTimer

### DIFF
--- a/KAIN2/Game/TIMER.C
+++ b/KAIN2/Game/TIMER.C
@@ -2,7 +2,7 @@
 #include "TIMER.H"
 #include "PSX/MAIN.H"
 
-long gameTimer; // 0x800CE188
+volatile int gameTimer; // 0x800D05F0
 
 #if defined(PSXPC_VERSION)
 unsigned long long TIMER_GetTimeMS()

--- a/KAIN2/Game/TIMER.H
+++ b/KAIN2/Game/TIMER.H
@@ -1,7 +1,7 @@
 #ifndef TIMER_H
 #define TIMER_H
 
-extern long gameTimer; // 0x800CE188
+extern volatile int gameTimer; // 0x800D05F0
 
 
 #if defined(PSXPC_VERSION)


### PR DESCRIPTION
The following scratches only match if gameTimer is declared as a volatile int: https://decomp.me/scratch/M4Ixs, https://decomp.me/scratch/PeG9I