### PR TITLE
[MONSTER]: Fix bad include

### DIFF
--- a/KAIN2/Game/MONSTER/MONSTER.C
+++ b/KAIN2/Game/MONSTER/MONSTER.C
@@ -6,7 +6,7 @@
 #include <Game/SAVEINFO.H>
 #include <Game/STREAM.H>
 #include <Game/MATH3D.H>
-#include <GAME/CAMERA.H>
+#include <Game/CAMERA.H>
 #include <Game/STATE.H>
 #include <Game/G2/ANMG2ILF.H>
 #include <Game/FX.H>


### PR DESCRIPTION
MONSTER.C contained an include that would cause a build failure on case-sensitive operating systems:
`#include <GAME/CAMERA.H>`
This PR corrects that, and the project will now successfully build on Linux.